### PR TITLE
feat: add session statistics command

### DIFF
--- a/.claude/current-task.json
+++ b/.claude/current-task.json
@@ -1,0 +1,8 @@
+{
+  "issue_number": 1,
+  "issue_title": "[Feature] Add session statistics command",
+  "branch": "feat/1-session-stats",
+  "type": "feat",
+  "description": "Add session-log stats command to display session statistics",
+  "created_at": "2025-01-15T14:10:00Z"
+}

--- a/cli_session_log/cli.py
+++ b/cli_session_log/cli.py
@@ -149,6 +149,51 @@ def cmd_close(args, manager: SessionManager):
         sys.exit(1)
 
 
+def cmd_stats(args, manager: SessionManager):
+    """Display session statistics."""
+    sessions = manager.list_sessions(None)
+
+    if not sessions:
+        print("No sessions found.")
+        return
+
+    # Count by status
+    status_counts = {"active": 0, "paused": 0, "completed": 0}
+    total_messages = {"user": 0, "ai": 0}
+
+    for s in sessions:
+        status = s.get("status", "active")
+        if status in status_counts:
+            status_counts[status] += 1
+
+        # Count messages if available
+        if "user_messages" in s:
+            total_messages["user"] += s["user_messages"]
+        if "ai_messages" in s:
+            total_messages["ai"] += s["ai_messages"]
+
+    total = len(sessions)
+
+    print("=" * 40)
+    print("       SESSION STATISTICS")
+    print("=" * 40)
+    print()
+    print(f"  Total Sessions:    {total}")
+    print()
+    print("  By Status:")
+    print(f"    Active:          {status_counts['active']}")
+    print(f"    Paused:          {status_counts['paused']}")
+    print(f"    Completed:       {status_counts['completed']}")
+    print()
+    if total_messages["user"] > 0 or total_messages["ai"] > 0:
+        print("  Messages:")
+        print(f"    User:            {total_messages['user']}")
+        print(f"    AI:              {total_messages['ai']}")
+        print(f"    Total:           {total_messages['user'] + total_messages['ai']}")
+        print()
+    print("=" * 40)
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="session-log",
@@ -194,6 +239,9 @@ def main():
     p_close = subparsers.add_parser("close", help="Close a session")
     p_close.add_argument("id", help="Session ID")
 
+    # stats
+    subparsers.add_parser("stats", help="Display session statistics")
+
     args = parser.parse_args()
 
     # Initialize manager
@@ -209,6 +257,7 @@ def main():
         "task": cmd_task,
         "status": cmd_status,
         "close": cmd_close,
+        "stats": cmd_stats,
     }
 
     commands[args.command](args, manager)


### PR DESCRIPTION
## Summary

Add `session-log stats` command that displays session statistics.

## Related Issue

Closes #1

## Changes Made

- Add `cmd_stats()` function to display statistics
- Add `stats` subcommand to CLI parser
- Display total sessions, status breakdown, and message counts

## Test Plan

- [ ] Run `session-log stats` and verify output format
- [ ] Test with no sessions (should show "No sessions found")
- [ ] Test with sessions in different statuses

---
Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new CLI command for viewing aggregate session metrics.
> 
> - Adds `cmd_stats()` to compute totals, status counts (`active`, `paused`, `completed`), and message counts (`user`, `ai`) from `manager.list_sessions(None)`
> - Registers `stats` subcommand in the argparse setup and dispatch map in `cli.py`
> - Outputs a formatted summary or "No sessions found." when there are no sessions
> - Adds `.claude/current-task.json` metadata for the feature
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 445258b8886fd3ef0d19d3d3b51eba839366baf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->